### PR TITLE
Implement better error recovery

### DIFF
--- a/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
+++ b/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
@@ -579,7 +579,9 @@ public class DataEventListener implements Listener {
 				});
 			} catch (IOException e) {
 				// there's nothing we can do here if we can't create the directory...
-				mLogger.log(Level.SEVERE, "Failed to create directory for saving player info", e);
+				mLogger.log(Level.SEVERE, "Failed to create directory for saving player info");
+				// TODO Copy MessagingUtils.sendStacktrace(CommandSender, Throwable) into this plugin and/or monumenta-lib, throw to Bukkit.getConsoleSender
+				ex.printStackTrace();
 			}
 
 			mLogger.severe("Bail: kicking player early in order to prevent data loss!");

--- a/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
+++ b/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
@@ -29,7 +29,6 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -580,7 +579,7 @@ public class DataEventListener implements Listener {
 				});
 			} catch (IOException e) {
 				// there's nothing we can do here if we can't create the directory...
-				mLogger.log(Level.SEVERE, "Failed to store player data!", e);
+				mLogger.log(Level.SEVERE, "Failed to create directory for saving player info", e);
 			}
 
 			mLogger.severe("Bail: kicking player early in order to prevent data loss!");

--- a/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
+++ b/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
@@ -577,7 +577,7 @@ public class DataEventListener implements Listener {
 						Files.writeString(dest.resolve(ent.getKey() + ".json"), ent.getValue());
 					}
 				});
-			}catch (IOException e) {
+			} catch (IOException e) {
 				// there's nothing we can do here if we can't create the directory...
 				mLogger.log(Level.SEVERE, "Failed to store player data!", e);
 			}

--- a/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
+++ b/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
@@ -553,8 +553,7 @@ public class DataEventListener implements Listener {
 			}
 
 			mLogger.severe("Bail: kicking player early in order to prevent data loss!");
-
-			event.getPlayer().kick();
+			Bukkit.getScheduler().runTask(MonumentaRedisSync.getInstance(), () -> event.getPlayer().kick());
 		}
 	}
 

--- a/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
+++ b/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
@@ -26,6 +26,7 @@ import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
@@ -558,7 +559,7 @@ public class DataEventListener implements Listener {
 
 			final var rootPath = MonumentaRedisSync.getInstance().getDataFolder().toPath()
 				.resolve("data-fail-report-%s-%s-%s".formatted(
-					new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS").format(new Date()),
+					new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS").format(Instant.now()),
 					player.getName(),
 					player.getUniqueId()
 				));

--- a/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
+++ b/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;

--- a/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
+++ b/plugin/src/main/java/com/playmonumenta/redissync/DataEventListener.java
@@ -579,9 +579,7 @@ public class DataEventListener implements Listener {
 				});
 			} catch (IOException e) {
 				// there's nothing we can do here if we can't create the directory...
-				mLogger.log(Level.SEVERE, "Failed to create directory for saving player info");
-				// TODO Copy MessagingUtils.sendStacktrace(CommandSender, Throwable) into this plugin and/or monumenta-lib, throw to Bukkit.getConsoleSender
-				ex.printStackTrace();
+				mLogger.log(Level.SEVERE, "Failed to create directory for saving player info", e);
 			}
 
 			mLogger.severe("Bail: kicking player early in order to prevent data loss!");


### PR DESCRIPTION
If playerdata fails to load, be smart and kick the player, then dump their playerdata to a file for debugging.

TODO: we should skip the save event.